### PR TITLE
change to .get('extractor')

### DIFF
--- a/asset_scanner/scripts/asset_scanner.py
+++ b/asset_scanner/scripts/asset_scanner.py
@@ -59,7 +59,7 @@ def load_extractor(conf: dict) -> BaseExtractor:
 
     extractor = None
 
-    if conf['extractor']:
+    if conf.get('extractor'):
         extractor = locate(conf['extractor'])
 
     if not extractor:


### PR DESCRIPTION
To stop the KeyError when extractor isn't included in the config.