### PR TITLE
print data with json formatting

### DIFF
--- a/asset_scanner/plugins/output_plugins/standard_out.py
+++ b/asset_scanner/plugins/output_plugins/standard_out.py
@@ -31,6 +31,7 @@ __license__ = "BSD - see LICENSE file in top-level package directory"
 __contact__ = "richard.d.smith@stfc.ac.uk"
 
 from .base import OutputBackend
+import json
 
 
 class StdoutOutputBackend(OutputBackend):
@@ -46,4 +47,4 @@ class StdoutOutputBackend(OutputBackend):
         :param data: Data from extraction process
         :param kwargs: Not used
         """
-        print(data)
+        print(json.dumps(data, indent=4))


### PR DESCRIPTION
Something I often do on my local end. Thought it might be useful to have in the upstream:
print the to `standard out` with JSON formatting for readability.