### PR TITLE
Add NcML backend to header_extract

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.6.0
     hooks:
     -   id: black
         language_version: python3
@@ -16,6 +16,6 @@ repos:
     hooks:
     -   id: flake8
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.9.3
+    rev: 5.10.1
     hooks:
         - id: isort

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,4 @@
+# Changes
+
+## v1.1.0 (unreleased)
+- Add NcML backend for `header_extract` processor, allowing global metadata to be parsed from the THREDDS NCML service, or the `ncdump -xh` command.

--- a/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
+++ b/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
@@ -79,7 +79,9 @@ def get_ncml(filepath: str) -> bytes:
     return get_ncml_from_fs(filepath)
 
 
-def get_ncml_from_thredds(filepath: str, catalog: str = None, dataset: str = None) -> bytes:
+def get_ncml_from_thredds(
+    filepath: str, catalog: str = None, dataset: str = None
+) -> bytes:
     """Read NcML response from THREDDS server.
 
     Parameters
@@ -114,6 +116,7 @@ def get_ncml_from_thredds(filepath: str, catalog: str = None, dataset: str = Non
 def get_ncml_from_fs(filepath: str) -> bytes:
     """Return NcML file description using `ncdump` utility."""
     import subprocess
+
     cmd = ["ncdump", "-hx", filepath]
     proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     return proc.stdout.read()
@@ -123,7 +126,7 @@ def to_element(content: bytes) -> Element:
     """Parse NcML file into XML node."""
 
     # Parse XML content - UTF-8 encoded documents need to be read as bytes
-    parser = XMLParser(encoding='UTF-8')
+    parser = XMLParser(encoding="UTF-8")
     return fromstring(content, parser=parser)
 
 

--- a/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
+++ b/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
@@ -9,6 +9,8 @@ __license__ = "BSD - see LICENSE file in top-level package directory"
 __contact__ = "huard.david@ouranos.ca"
 
 from typing import List
+
+import requests.exceptions
 from lxml.etree import XMLParser, fromstring, Element
 
 # NcML namespace
@@ -31,7 +33,7 @@ class NcMLBackend:
         try:
             get_ncml(filepath)
             return True
-        except ValueError:
+        except requests.exceptions.HTTPError:
             return False
 
     def attr_extraction(self, file: str, attributes: List, **kwargs) -> dict:
@@ -89,6 +91,7 @@ def get_ncml(url: str, catalog: str = None, dataset: str = None) -> bytes:
 
     r = requests.get(url, params=params)
     # logger.info(r.url)
+    r.raise_for_status()
     return r.content
 
 

--- a/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
+++ b/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
@@ -13,7 +13,7 @@ __contact__ = "huard.david@ouranos.ca"
 from typing import List
 
 import requests.exceptions
-from lxml.etree import XMLParser, fromstring, Element
+from lxml.etree import Element, XMLParser, fromstring
 
 # NcML namespace
 NS = {"ncml": "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"}

--- a/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
+++ b/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
@@ -1,0 +1,140 @@
+# encoding: utf-8
+"""
+Collection of functions which can be used to extract metadata from file headers
+"""
+__author__ = "David Huard"
+__date__ = "June 2022"
+__copyright__ = "Copyright 2022 Ouranos"
+__license__ = "BSD - see LICENSE file in top-level package directory"
+__contact__ = "huard.david@ouranos.ca"
+
+from typing import List
+from lxml.etree import XMLParser, fromstring, Element
+
+# NcML namespace
+NS = {"ncml": "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"}
+
+
+class NcMLBackend:
+    """
+    NcML
+    ----
+
+    Backend Name: ``NcML``
+
+    Description:
+        Takes an input string and returns a boolean on whether this
+        backend can open that file.
+    """
+
+    def guess_can_open(self, filepath: str) -> bool:
+        try:
+            get_ncml(filepath)
+            return True
+        except ValueError:
+            return False
+
+    def attr_extraction(self, file: str, attributes: List, **kwargs) -> dict:
+        """
+        Takes a filepath and list of attributes and extracts the metadata.
+
+        :param file: file-like object
+        :param attributes: attributes to extract
+        :param kwargs: {}
+
+        :return: Dictionary of extracted attributes
+        """
+        content = get_ncml(file)
+        elem = to_element(content)
+
+        extracted_metadata = {}
+        for attr in attributes:
+            expr = attribute(attr)
+            value = elem.xpath(expr, namespaces=NS)
+
+            if value:
+                extracted_metadata[attr] = value[0]
+
+        return extracted_metadata
+
+
+def get_ncml(url: str, catalog: str = None, dataset: str = None) -> bytes:
+    """Read NcML response from server.
+
+    Providing the catalog and dataset reproduces the NcML response we get when we click on the NcML service on THREDDS.
+
+    Parameters
+    ----------
+    url : str
+      Link to NcML service of dataset hosted on a THREDDS server.
+    catalog : str
+      Link to catalog storing the dataset.
+    dataset : str
+      Relative link to the dataset.
+
+    Returns
+    -------
+    bytes
+      NcML content
+    """
+    import requests
+
+    # For some reason, this is required to obtain the "THREDDSMetadata" group and the available services.
+    # Note that the OPENDAP link would have been available from the top "location" attribute.
+    params = {}
+    if catalog:
+        params["catalog"] = catalog
+    if dataset:
+        params["dataset"] = dataset
+
+    r = requests.get(url, params=params)
+    # logger.info(r.url)
+    return r.content
+
+
+def to_element(content: bytes) -> Element:
+    """Parse NcML file into XML node."""
+
+    # Parse XML content - UTF-8 encoded documents need to be read as bytes
+    parser = XMLParser(encoding='UTF-8')
+    return fromstring(content, parser=parser)
+
+
+def attribute(name: str) -> str:
+    """Return xpath expression for global NcML attributes."""
+    return f"//ncml:attribute[@name='{name}']/@value"
+
+
+def varattr(name: str) -> str:
+    """Return xpath expression for NcML variable attributes."""
+    return f"./ncml:attribute[@name='{name}']/@value"
+
+
+def dimlen(name: str) -> str:
+    """Return xpath expression for NcML dimension length"""
+    return f"./ncml:dimension[@name='{name}']/@length"
+
+
+def get_variables(elem: Element) -> Element:
+    """Return <variable> nodes that are not coordinates.
+
+    Parameters
+    ----------
+    elem : lxml.etree.Element
+      <ncml:netcdf> element.
+    """
+
+    # Get bounds
+    bexpr = "./ncml:variable[ncml:attribute[@name='_CoordinateAxisType']]/ncml:attribute[@name='bounds']/@value"
+    bounds = elem.xpath(bexpr, namespaces=NS)
+
+    # Filter variables that are not coordinates
+    vexpr = "./ncml:variable[not(ncml:attribute[@name='_CoordinateAxisType'])]"
+    elements = elem.xpath(vexpr, namespaces=NS)
+
+    # Get dimension names
+    dexpr = "./ncml:dimension/@name"
+    dimensions = elem.xpath(dexpr, namespaces=NS)
+
+    exclude = bounds + dimensions
+    return [el for el in elements if el.xpath("@name")[0] not in exclude]

--- a/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
+++ b/asset_scanner/plugins/extraction_methods/header_extract/backends/ncml.py
@@ -1,12 +1,14 @@
 # encoding: utf-8
 """
-Collection of functions which can be used to extract metadata from file headers
+Metadata extraction backend for NcML (XML) description files.
 """
 __author__ = "David Huard"
 __date__ = "June 2022"
 __copyright__ = "Copyright 2022 Ouranos"
 __license__ = "BSD - see LICENSE file in top-level package directory"
 __contact__ = "huard.david@ouranos.ca"
+
+# Note that some of the XML parsing functions below are not used at the moment, but included for future reference.
 
 from typing import List
 
@@ -23,13 +25,10 @@ class NcMLBackend:
     ----
 
     Backend Name: ``NcML``
-
-    Description:
-        Takes an input string and returns a boolean on whether this
-        backend can open that file.
     """
 
     def guess_can_open(self, filepath: str) -> bool:
+        """Return a boolean on whether this backend can open that file."""
         try:
             get_ncml(filepath)
             return True
@@ -46,12 +45,18 @@ class NcMLBackend:
 
         :return: Dictionary of extracted attributes
         """
+        # Send GET request to server for the THREDDS NCML response
         content = get_ncml(file)
+
+        # Convert response to an XML etree.Element
         elem = to_element(content)
 
         extracted_metadata = {}
         for attr in attributes:
+            # xpath expression to parse XML and extract attribute
             expr = attribute(attr)
+
+            # Execute xpath expression
             value = elem.xpath(expr, namespaces=NS)
 
             if value:

--- a/asset_scanner/plugins/input_plugins/thredds_input.py
+++ b/asset_scanner/plugins/input_plugins/thredds_input.py
@@ -28,13 +28,21 @@ as a source.
         <https://unidata.github.io/siphon/latest/api/catalog.html#siphon.catalog.TDSCatalog>`_
 
 
-Example Configuration:
+Example Configuration with OPENDAP:
     .. code-block:: yaml
 
         inputs:
             - name: thredds
               uri: test-url
               object_path_attr: access_urls.OPENDAP
+
+Example Configuration with NCML:
+    .. code-block:: yaml
+
+        inputs:
+            - name: thredds
+              uri: test-url
+              object_path_attr: access_urls.NCML
 
 """
 __author__ = "Mathieu Provencher"

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             "vocab = asset_scanner.plugins.post_extraction_methods.vocab_post_extract:VocabPostExtract",
         ],
         "asset_scanner.extraction_methods.header_extract.backends": [
+            "ncml = asset_scanner.plugins.extraction_methods.header_extract.backends.ncml:NcMLBackend",
             "xarray = asset_scanner.plugins.extraction_methods.header_extract.backends.xarray:XarrayBackend",
             "cf = asset_scanner.plugins.extraction_methods.header_extract.backends.cf:CfBackend",
         ],


### PR DESCRIPTION
This PR adds a backend to header_extract that enables using THREDDS' NCML service to extract metadata attributes. 
It supports 
- paths pointing to the NCML THREDDS service;
- filesystem paths, in which case it uses `ncdump -xh` to get XML description of attributes.

For the `thredds` input plugin: 
- make sure the paths in item description includes the ncml endpoint (not dodsC); 
- set `object_path_attr: access_urls.NCML` 

I've tested it locally, both on the filesystem and a THREDDS service, but there are no test included in the code. 

Fixes #39 