### PR TITLE
Pydantic validator post extraction processor

### DIFF
--- a/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
+++ b/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
@@ -65,12 +65,12 @@ class ControlledVocabularyPostExtract(BaseProcessor):
         klass = getattr(module, scopes[-1])
 
         # Get metadata attributes
-        properties = data["properties"]
+        properties = data["body"]["properties"]
 
         # Instantiate data model
         try:
             cv = klass(**properties)
-            data["properties"] = cv.dict()
+            data["body"]["properties"] = cv.dict()
 
         except pydantic.ValidationError as exc:
             LOGGER.warning(exc)

--- a/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
+++ b/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
@@ -12,7 +12,7 @@ import logging
 
 import pydantic
 
-from asset_scanner.core.decorators import accepts_postprocessors, accepts_preprocessors
+from asset_scanner.core.decorators import accepts_postprocessors
 from asset_scanner.core.processor import BaseProcessor
 
 LOGGER = logging.getLogger(__name__)

--- a/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
+++ b/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
@@ -2,7 +2,7 @@
 
 __author__ = "David Huard"
 __date__ = "June 2022"
-__copyright__ = "Copyright 2018 Ouranos"
+__copyright__ = "Copyright 2022 Ouranos"
 __license__ = "BSD - see LICENSE file in top-level package directory"
 __contact__ = "huard.david@ouranos.ca"
 

--- a/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
+++ b/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
@@ -1,0 +1,73 @@
+# encoding: utf-8
+
+__author__ = "David Huard"
+__date__ = "June 2022"
+__copyright__ = "Copyright 2018 Ouranos"
+__license__ = "BSD - see LICENSE file in top-level package directory"
+__contact__ = "huard.david@ouranos.ca"
+
+
+# Python imports
+import logging
+
+from asset_scanner.core.decorators import accepts_postprocessors, accepts_preprocessors
+from asset_scanner.core.processor import BaseProcessor
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ControlledVocabularyPostExtract(BaseProcessor):
+    """
+
+    .. list-table::
+
+        * - Processor Name
+          - ``controlled_vocabulary``
+        * - Accepts Pre-processors
+          -
+        * - Accepts Post-processors
+          - .. fa:: check
+
+    Description:
+        Compare properties to a controlled vocabulary defined by a pydantic.BaseModel.
+
+    Configuration Options:
+        - ``model``: pydantic.BaseModel subclass to be imported at run-time, e.g. `package.module.class_name`.
+
+    Example Configuration:
+
+    .. code-block:: yaml
+
+        post_processors:
+            - name: controlled_vocabulary
+              inputs:
+                model:
+                  my_cv.collections.CMIP5
+    """
+
+    @accepts_postprocessors
+    def run(
+        self,
+        data: dict,
+        source_media: str = "POSIX",
+        **kwargs,
+    ) -> dict:
+        import importlib
+
+        # Import data model
+        scopes = self.model.split('.')
+        module = '.'.join(scopes[:-1])
+
+        module = importlib.import_module(module)
+        klass = getattr(module, scopes[-1])
+
+        # Get metadata attributes
+        properties = data["body"]["properties"]
+
+        # Instantiate data model
+        cv = klass(**properties)
+
+        # Return validated properties. Could be different from original properties (default values, processing, etc.)
+        data["body"]["properties"] = cv.dict()
+
+        return data

--- a/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
+++ b/asset_scanner/plugins/post_extraction_methods/cv_post_extract.py
@@ -58,8 +58,8 @@ class ControlledVocabularyPostExtract(BaseProcessor):
         import importlib
 
         # Import data model
-        scopes = self.model.split('.')
-        module = '.'.join(scopes[:-1])
+        scopes = self.model.split(".")
+        module = ".".join(scopes[:-1])
 
         module = importlib.import_module(module)
         klass = getattr(module, scopes[-1])

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         ],
         "asset_scanner.post_extraction_methods": [
             "vocab = asset_scanner.plugins.post_extraction_methods.vocab_post_extract:VocabPostExtract",
-            "controlled_vocabulary = asset_scanner.plugins.post_extraction_methods.cv_post_extract:ControlledVocabularyPostExtract"
+            "controlled_vocabulary = asset_scanner.plugins.post_extraction_methods.cv_post_extract:ControlledVocabularyPostExtract",
         ],
         "asset_scanner.extraction_methods.header_extract.backends": [
             "xarray = asset_scanner.plugins.extraction_methods.header_extract.backends.xarray:XarrayBackend",

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         ],
         "asset_scanner.post_extraction_methods": [
             "vocab = asset_scanner.plugins.post_extraction_methods.vocab_post_extract:VocabPostExtract",
+            "controlled_vocabulary = asset_scanner.plugins.post_extraction_methods.cv_post_extract:ControlledVocabularyPostExtract"
         ],
         "asset_scanner.extraction_methods.header_extract.backends": [
             "xarray = asset_scanner.plugins.extraction_methods.header_extract.backends.xarray:XarrayBackend",


### PR DESCRIPTION
- Add a post_extraction_processor that uses a pydantic.BaseModel to validate facet properties. 

I believe this is similar to the `vocab` post_extraction_method, but instead of sending a request to an ontology service, it runs the properties through a user-defined pydantic data model, for example:

```
from pydantic import BaseModel
from typing import Literal

class CMIP5(BaseModel):
    experiment_id: Literal["rcp45", "rcp85"]
    frequency: Literal["amon", "day"]
```


